### PR TITLE
Define acitve_handlers with service_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Define service_id in initializer with active_handlers, instead of handler class.
+
 ## 0.1.0
 
 - Initial release

--- a/example/app/webhooks/webhook_test_handler.rb
+++ b/example/app/webhooks/webhook_test_handler.rb
@@ -17,10 +17,6 @@ class WebhookTestHandler < Munster::BaseHandler
     raise
   end
 
-  def self.service_id
-    :test
-  end
-
   def self.expose_errors_to_sender?
     true
   end

--- a/lib/munster/base_handler.rb
+++ b/lib/munster/base_handler.rb
@@ -26,14 +26,6 @@ module Munster
       def process(received_webhook)
       end
 
-      # This should be defined for each webhook handler and should be unique.
-      # Otherwise controller will never pick up, that this handler exists.
-      #
-      # Please consider that this will be used in url, so don't use underscores or any other symbols that are not used in URL.
-      def service_id
-        :base
-      end
-
       # This method verifies that request actually comes from provider:
       # signature validation, HTTP authentication, IP whitelisting and the like
       def valid?(action_dispatch_request)

--- a/lib/munster/controllers/receive_webhooks_controller.rb
+++ b/lib/munster/controllers/receive_webhooks_controller.rb
@@ -47,7 +47,7 @@ module Munster
     end
 
     def lookup_handler(service_id_str)
-      Munster.configuration.active_handlers.index_by(&:service_id).fetch(service_id_str.to_sym)
+      Munster.configuration.active_handlers.with_indifferent_access.fetch(service_id_str)
     end
   end
 end

--- a/lib/munster/templates/munster.rb
+++ b/lib/munster/templates/munster.rb
@@ -1,4 +1,7 @@
 Munster.configure do |config|
-  config.active_handlers = []
+  # Active Handlers are defined as hash with key as a service_id and handler class  that would handle webhook request.
+  # Example:
+  #   {:test => TestHandler, :inactive => InactiveHandler}
+  config.active_handlers = {}
   config.processing_job_class = Munster::ProcessingJob
 end

--- a/test/dummy/app/webhooks/extract_id_handler.rb
+++ b/test/dummy/app/webhooks/extract_id_handler.rb
@@ -2,6 +2,4 @@ class ExtractIdHandler < WebhookTestHandler
   def self.extract_event_id_from_request(action_dispatch_request)
      JSON.parse(action_dispatch_request.body.read).fetch("event_id")
   end
-
-  def self.service_id = :extract_id
 end

--- a/test/dummy/app/webhooks/inactive_handler.rb
+++ b/test/dummy/app/webhooks/inactive_handler.rb
@@ -2,6 +2,4 @@
 
 class InactiveHandler < WebhookTestHandler
   def self.active? = false
-
-  def self.service_id = :inactive
 end

--- a/test/dummy/app/webhooks/invalid_handler.rb
+++ b/test/dummy/app/webhooks/invalid_handler.rb
@@ -2,6 +2,4 @@
 
 class InvalidHandler < WebhookTestHandler
   def self.valid?(request) = false
-
-  def self.service_id = :invalid
 end

--- a/test/dummy/app/webhooks/private_handler.rb
+++ b/test/dummy/app/webhooks/private_handler.rb
@@ -1,7 +1,5 @@
 
 class PrivateHandler < WebhookTestHandler
   def self.valid?(request) = false
-
-  def self.service_id = :private
   def self.expose_errors_to_sender? = false
 end

--- a/test/dummy/app/webhooks/webhook_test_handler.rb
+++ b/test/dummy/app/webhooks/webhook_test_handler.rb
@@ -16,10 +16,6 @@ class WebhookTestHandler < Munster::BaseHandler
     webhook.update!(status: "error")
   end
 
-  def self.service_id
-    :test
-  end
-
   def self.expose_errors_to_sender?
     true
   end

--- a/test/dummy/config/initializers/munster.rb
+++ b/test/dummy/config/initializers/munster.rb
@@ -7,5 +7,11 @@ require_relative "../../app/webhooks/private_handler"
 require_relative "../../app/webhooks/extract_id_handler"
 
 Munster.configure do |config|
-  config.active_handlers = [WebhookTestHandler, InactiveHandler, InvalidHandler, PrivateHandler, ExtractIdHandler]
+  config.active_handlers = {
+    :test => WebhookTestHandler,
+    :inactive => InactiveHandler,
+    :invalid => InvalidHandler,
+    :private => PrivateHandler,
+    :extract_id => ExtractIdHandler
+  }
 end


### PR DESCRIPTION
Now we defined `active_handlers` attributes as a hash - where key is a service_id. 

This gives good overview of what kind of service_id we support. No need to lookup each and other handler to figure that out.