### PR TITLE
Provide handled: true attribute for Rails.error.report method, because it is  required in Rails 7.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Pbbuilder Changelog
 All notable changes to this project will be documented in this file.
 
-This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,23 @@
+# Pbbuilder Changelog
+All notable changes to this project will be documented in this file.
+
+This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Fixed
+- Provide handled: true attribute for Rails.error.report method, because it is  required in Rails 7.0.
+
 ## 0.2.0
+
+### Changed
 
 - Handler methods are now defined as instance methods for simplicity.
 - Define service_id in initializer with active_handlers, instead of handler class.
 - Use ruby 3.0 as a base for standard/rubocop, format all code according to it.
+
+### Added
+
 - Introduce Rails common error reporter ( https://guides.rubyonrails.org/error_reporting.html )
 
 ## 0.1.0

--- a/lib/munster/controllers/receive_webhooks_controller.rb
+++ b/lib/munster/controllers/receive_webhooks_controller.rb
@@ -20,7 +20,7 @@ module Munster
       render_error("Required parameters were not present in the request", :not_found)
     rescue => e
       Rails.error.set_context(**Munster.configuration.error_context)
-      Rails.error.report(e)
+      Rails.error.report(e, handled: true, severity: :error)
 
       if handler&.expose_errors_to_sender?
         error_for_sender_from_exception(e)

--- a/lib/munster/controllers/receive_webhooks_controller.rb
+++ b/lib/munster/controllers/receive_webhooks_controller.rb
@@ -20,6 +20,8 @@ module Munster
       render_error("Required parameters were not present in the request", :not_found)
     rescue => e
       Rails.error.set_context(**Munster.configuration.error_context)
+      # Rails 7.1 only requires `error` attribute for .report method, but Rails 7.0 requires `handled:` attribute additionally.
+      # We're setting `handled:` and `severity:` attributes to maintain compatibility with all versions of > rails 7.
       Rails.error.report(e, handled: true, severity: :error)
 
       if handler&.expose_errors_to_sender?


### PR DESCRIPTION
`handled: true` attribute is required for `Rails.error.report` method in Rails 7.0, but not required in Rails 7.1.

See relevant code in rails.

- Rails 7.0 code, that require "handled: true" - https://github.com/rails/rails/blob/v7.0.8.4/activesupport/lib/active_support/error_reporter.rb#L95

- Rails 7.1 code, that doesn't require this attribute -  https://github.com/rails/rails/blob/main/activesupport/lib/active_support/error_reporter.rb#L210