### PR TITLE
Fixes: active_job/railtie, re-enqueue webhook that errored out

### DIFF
--- a/lib/munster/base_handler.rb
+++ b/lib/munster/base_handler.rb
@@ -21,7 +21,7 @@ module Munster
       Rails.logger.info { "#{inspect} Webhook #{handler_event_id} is a duplicate delivery and will not be stored." }
     end
 
-    # Enqueues the processing job to process webhook asynchronously. The job class could be configured configured.
+    # Enqueues the processing job to process webhook asynchronously. The job class could be configured.
     #
     # @param webhook [Munster::ReceivedWebhook]
     # @return [void]

--- a/lib/munster/base_handler.rb
+++ b/lib/munster/base_handler.rb
@@ -16,6 +16,16 @@ module Munster
       webhook = Munster::ReceivedWebhook.new(request: action_dispatch_request, handler_event_id: handler_event_id, handler_module_name: handler_module_name)
       webhook.save!
 
+      enqueue(webhook)
+    rescue ActiveRecord::RecordNotUnique # Webhook deduplicated
+      Rails.logger.info { "#{inspect} Webhook #{handler_event_id} is a duplicate delivery and will not be stored." }
+    end
+
+    # Enqueues the processing job to process webhook asynchronously. The job class could be configured configured.
+    #
+    # @param webhook [Munster::ReceivedWebhook]
+    # @return [void]
+    def enqueue(webhook)
       # The configured job class can be a class name or a module, to support lazy loading
       job_class_or_module_name = Munster.configuration.processing_job_class
       job_class = if job_class_or_module_name.respond_to?(:perform_later)
@@ -25,8 +35,6 @@ module Munster
       end
 
       job_class.perform_later(webhook)
-    rescue ActiveRecord::RecordNotUnique # Webhook deduplicated
-      Rails.logger.info { "#{inspect} Webhook #{handler_event_id} is a duplicate delivery and will not be stored." }
     end
 
     # This is the heart of your webhook processing. Override this method and define your processing inside of it.

--- a/lib/munster/jobs/processing_job.rb
+++ b/lib/munster/jobs/processing_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "active_job" if defined?(Rails)
+require "active_job/railtie"
 
 module Munster
   class ProcessingJob < ActiveJob::Base

--- a/lib/munster/models/received_webhook.rb
+++ b/lib/munster/models/received_webhook.rb
@@ -15,6 +15,11 @@ module Munster
       s.permit_transition(:processing, :skipped)
       s.permit_transition(:processing, :processed)
       s.permit_transition(:processing, :error)
+      s.permit_transition(:error, :received)
+
+      s.after_committed_transition_to(:received) do |webhook|
+        webhook.handler.enqueue(webhook)
+      end
     end
 
     # Store the pertinent data from an ActionDispatch::Request into the webhook.

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -3,7 +3,6 @@
 require "active_record"
 require "action_pack"
 require "action_controller"
-require "active_job/railtie"
 require "rails"
 
 database = "development.sqlite3"


### PR DESCRIPTION
Two small improvements to Munster:

- Webhook processor should require `active_job/railtie`, not just `active_job`. It require GlobalID to work and that get's required only with railtie.
- We're adding a state transition from `error` to `received`. System will enqueue webhook processing, if this transition was executed.