### PR TITLE
Update examples to use instance methods

### DIFF
--- a/handler-examples/revolut_business_v1_handler.rb
+++ b/handler-examples/revolut_business_v1_handler.rb
@@ -5,7 +5,7 @@ class RevolutBusinessV1Handler < Munster::BaseHandler
     true
   end
 
-  def self.process(webhook)
+  def process(webhook)
     parsed_payload = JSON.parse(webhook.body)
     topic = parsed_payload.fetch("Topic")
     case topic
@@ -18,7 +18,7 @@ class RevolutBusinessV1Handler < Munster::BaseHandler
     end
   end
 
-  def self.extract_event_id_from_request(action_dispatch_request)
+  def extract_event_id_from_request(action_dispatch_request)
     # Since b-tree indices generally divide from the start of the string, place the highest
     # entropy component at the start (the EventId)
     key_components = %w[EventId Topic Version]

--- a/handler-examples/revolut_business_v2_handler.rb
+++ b/handler-examples/revolut_business_v2_handler.rb
@@ -30,11 +30,11 @@ class RevolutBusinessV2Handler < Munster::BaseHandler
     matches.any?
   end
 
-  def self.process(webhook)
+  def process(webhook)
     Rails.logger.info { "Processing Revolut webhook #{webhook.body.inspect}" }
   end
 
-  def self.extract_event_id_from_request(action_dispatch_request)
+  def extract_event_id_from_request(action_dispatch_request)
     # The event ID is only available when you retrieve the failed webhooks, which is sad.
     # We can divinate a synthetic ID though by taking a hash of the entire payload though.
     Digest::SHA256.hexdigest(action_dispatch_request.body.read)


### PR DESCRIPTION
We forgot to update our examples to use instance methods, instead of class methods. 